### PR TITLE
refactor(mppi): use Eigen in mppi_acc CUDA kernels

### DIFF
--- a/src/fuel_planner/plan_bringup/config/mppi_acc.yaml
+++ b/src/fuel_planner/plan_bringup/config/mppi_acc.yaml
@@ -6,12 +6,12 @@ mppi_control:
       ctl_freq: 50.0 # Control frequency in Hz (dt = 1/ctl_freq)
       sigma: 0.1
       lambda: 0.001
-      Q_pos_x: 50.0
-      Q_pos_y: 50.0
-      Q_pos_z: 50.0
-      Q_vel_x: 5.0
-      Q_vel_y: 5.0
-      Q_vel_z: 5.0
+      Q_pos_x: 500.0
+      Q_pos_y: 500.0
+      Q_pos_z: 500.0
+      Q_vel_x: 50.0
+      Q_vel_y: 50.0
+      Q_vel_z: 50.0
       R_x: 0.5
       R_y: 0.5
       R_z: 0.5

--- a/src/fuel_planner/plan_bringup/config/mppi_acc.yaml
+++ b/src/fuel_planner/plan_bringup/config/mppi_acc.yaml
@@ -18,7 +18,7 @@ mppi_control:
       R_rate_x: 30.0
       R_rate_y: 30.0
       R_rate_z: 30.0
-      w_obs: 0.0
+      w_obs: 10.0
       a_max: 10.0
       tilt_max: 0.6
       g: 9.81

--- a/src/i_mppi/mppi_control/src/mppi_acc_kernels.cu
+++ b/src/i_mppi/mppi_control/src/mppi_acc_kernels.cu
@@ -2,6 +2,12 @@
 #include <curand_kernel.h>
 #include <device_launch_parameters.h>
 
+#define EIGEN_DEFAULT_DENSE_INDEX_TYPE int
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include "mppi_control/mppi_utils.cuh"
+
 extern "C"
 {
 
@@ -51,133 +57,104 @@ extern "C"
     curandState state;
     curand_init(seed, k, 0, &state);
 
-    float3 p = curr_p;
-    float3 v = curr_v;
+    Eigen::Vector3f p(curr_p.x, curr_p.y, curr_p.z);
+    Eigen::Vector3f v(curr_v.x, curr_v.y, curr_v.z);
     float total_cost = 0.0f;
-    float3 u_prev_timestep = u_prev; // Track previous control in this rollout
+    Eigen::Vector3f u_prev_timestep(u_prev.x, u_prev.y, u_prev.z); // Track previous control in this rollout
+
+    Eigen::Vector3f ref_p_base_v(ref_p_base.x, ref_p_base.y, ref_p_base.z);
+    Eigen::Vector3f ref_v_base_v(ref_v_base.x, ref_v_base.y, ref_v_base.z);
+    Eigen::Vector3f ref_a_base_v(ref_a_base.x, ref_a_base.y, ref_a_base.z);
 
     for (int h = 0; h < params.H; ++h)
     {
       // Reference Trajectory Prediction (Constant Acceleration Model)
       float t = (h + 1) * params.dt;
-      float3 ref_p, ref_v;
-      ref_p.x = ref_p_base.x + ref_v_base.x * t + 0.5f * ref_a_base.x * t * t;
-      ref_p.y = ref_p_base.y + ref_v_base.y * t + 0.5f * ref_a_base.y * t * t;
-      ref_p.z = ref_p_base.z + ref_v_base.z * t + 0.5f * ref_a_base.z * t * t;
-
-      ref_v.x = ref_v_base.x + ref_a_base.x * t;
-      ref_v.y = ref_v_base.y + ref_a_base.y * t;
-      ref_v.z = ref_v_base.z + ref_a_base.z * t;
+      Eigen::Vector3f ref_p = ref_p_base_v + ref_v_base_v * t + 0.5f * ref_a_base_v * t * t;
+      Eigen::Vector3f ref_v = ref_v_base_v + ref_a_base_v * t;
 
       // Generate noise
-      float3 noise;
-      noise.x = curand_normal(&state) * params.sigma;
-      noise.y = curand_normal(&state) * params.sigma;
-      noise.z = curand_normal(&state) * params.sigma;
+      Eigen::Vector3f noise;
+      noise.x() = curand_normal(&state) * params.sigma;
+      noise.y() = curand_normal(&state) * params.sigma;
+      noise.z() = curand_normal(&state) * params.sigma;
 
-      float3 u = u_mean[h];
-      u.x += noise.x;
-      u.y += noise.y;
-      u.z += noise.z;
+      Eigen::Vector3f u(u_mean[h].x, u_mean[h].y, u_mean[h].z);
+      u += noise;
 
       // Use ref_a_base as feed-forward
-      float3 total_u;
-      total_u.x = u.x + ref_a_base.x;
-      total_u.y = u.y + ref_a_base.y;
-      total_u.z = u.z + ref_a_base.z;
+      Eigen::Vector3f total_u = u + ref_a_base_v;
 
       // Constraints (Simplified for GPU kernel)
-      float3 total_acc = make_float3(total_u.x, total_u.y, total_u.z + params.g);
-      float thrust = sqrtf(total_acc.x * total_acc.x + total_acc.y * total_acc.y + total_acc.z * total_acc.z);
+      Eigen::Vector3f total_acc = total_u + Eigen::Vector3f(0.0f, 0.0f, params.g);
+      float thrust = total_acc.norm();
 
       if (thrust > params.a_max + params.g)
       {
-        float scale = (params.a_max + params.g) / thrust;
-        total_acc.x *= scale;
-        total_acc.y *= scale;
-        total_acc.z *= scale;
+        total_acc *= (params.a_max + params.g) / thrust;
         thrust = params.a_max + params.g;
       }
 
       // Tilt constraint (Angle with Z-axis)
-      float cos_tilt = total_acc.z / (thrust + 1e-6f);
+      float cos_tilt = total_acc.z() / (thrust + 1e-6f);
       if (cos_tilt < cosf(params.tilt_max))
       {
         // Project onto the cone
-        float s = sqrtf(total_acc.x * total_acc.x + total_acc.y * total_acc.y);
+        float s = total_acc.head<2>().norm();
         float target_s = thrust * sinf(params.tilt_max);
         float target_z = thrust * cosf(params.tilt_max);
         if (s > 1e-6f)
         {
-          total_acc.x *= target_s / s;
-          total_acc.y *= target_s / s;
+          total_acc.head<2>() *= target_s / s;
         }
-        total_acc.z = target_z;
+        total_acc.z() = target_z;
       }
 
-      total_u.x = total_acc.x;
-      total_u.y = total_acc.y;
-      total_u.z = total_acc.z - params.g;
+      total_u = total_acc - Eigen::Vector3f(0.0f, 0.0f, params.g);
 
       // Control to be stored and used in cost is the delta from reference
-      u.x = total_u.x - ref_a_base.x;
-      u.y = total_u.y - ref_a_base.y;
-      u.z = total_u.z - ref_a_base.z;
+      u = total_u - ref_a_base_v;
 
       // Store sample (the delta u)
-      samples_u[k * params.H + h] = u;
+      samples_u[k * params.H + h] = make_float3(u.x(), u.y(), u.z());
 
       // Dynamics Propagation using RK4 with total_u
       // State x = [p, v], dot(x) = [v, a]
-      float3 k1_p = v;
-      float3 k1_v = total_u;
+      Eigen::Vector3f k1_p = v;
+      Eigen::Vector3f k1_v = total_u;
 
-      float3 k2_p = make_float3(v.x + 0.5f * params.dt * k1_v.x, v.y + 0.5f * params.dt * k1_v.y, v.z + 0.5f * params.dt * k1_v.z);
-      float3 k2_v = total_u; // Acceleration is constant over dt
+      Eigen::Vector3f k2_p = v + 0.5f * params.dt * k1_v;
+      Eigen::Vector3f k2_v = total_u; // Acceleration is constant over dt
 
-      float3 k3_p = make_float3(v.x + 0.5f * params.dt * k2_v.x, v.y + 0.5f * params.dt * k2_v.y, v.z + 0.5f * params.dt * k2_v.z);
-      float3 k3_v = total_u;
+      Eigen::Vector3f k3_p = v + 0.5f * params.dt * k2_v;
+      Eigen::Vector3f k3_v = total_u;
 
-      float3 k4_p = make_float3(v.x + params.dt * k3_v.x, v.y + params.dt * k3_v.y, v.z + params.dt * k3_v.z);
-      float3 k4_v = total_u;
+      Eigen::Vector3f k4_p = v + params.dt * k3_v;
+      Eigen::Vector3f k4_v = total_u;
 
-      p.x += (params.dt / 6.0f) * (k1_p.x + 2.0f * k2_p.x + 2.0f * k3_p.x + k4_p.x);
-      p.y += (params.dt / 6.0f) * (k1_p.y + 2.0f * k2_p.y + 2.0f * k3_p.y + k4_p.y);
-      p.z += (params.dt / 6.0f) * (k1_p.z + 2.0f * k2_p.z + 2.0f * k3_p.z + k4_p.z);
-
-      v.x += (params.dt / 6.0f) * (k1_v.x + 2.0f * k2_v.x + 2.0f * k3_v.x + k4_v.x);
-      v.y += (params.dt / 6.0f) * (k1_v.y + 2.0f * k2_v.y + 2.0f * k3_v.y + k4_v.y);
-      v.z += (params.dt / 6.0f) * (k1_v.z + 2.0f * k2_v.z + 2.0f * k3_v.z + k4_v.z);
+      p += (params.dt / 6.0f) * (k1_p + 2.0f * k2_p + 2.0f * k3_p + k4_p);
+      v += (params.dt / 6.0f) * (k1_v + 2.0f * k2_v + 2.0f * k3_v + k4_v);
 
       // Cost calculation
-      float dp_x = p.x - ref_p.x;
-      float dp_y = p.y - ref_p.y;
-      float dp_z = p.z - ref_p.z;
-      float dv_x = v.x - ref_v.x;
-      float dv_y = v.y - ref_v.y;
-      float dv_z = v.z - ref_v.z;
-      float da_x = u.x - ref_a_base.x;
-      float da_y = u.y - ref_a_base.y;
-      float da_z = u.z - ref_a_base.z;
+      Eigen::Vector3f dp = p - ref_p;
+      Eigen::Vector3f dv = v - ref_v;
+      Eigen::Vector3f da = u - ref_a_base_v;
 
-      total_cost += params.Q_pos_x * dp_x * dp_x;
-      total_cost += params.Q_pos_y * dp_y * dp_y;
-      total_cost += params.Q_pos_z * dp_z * dp_z;
-      total_cost += params.Q_vel_x * dv_x * dv_x;
-      total_cost += params.Q_vel_y * dv_y * dv_y;
-      total_cost += params.Q_vel_z * dv_z * dv_z;
-      total_cost += params.R_x * da_x * da_x;
-      total_cost += params.R_y * da_y * da_y;
-      total_cost += params.R_z * da_z * da_z;
+      total_cost += params.Q_pos_x * dp.x() * dp.x();
+      total_cost += params.Q_pos_y * dp.y() * dp.y();
+      total_cost += params.Q_pos_z * dp.z() * dp.z();
+      total_cost += params.Q_vel_x * dv.x() * dv.x();
+      total_cost += params.Q_vel_y * dv.y() * dv.y();
+      total_cost += params.Q_vel_z * dv.z() * dv.z();
+      total_cost += params.R_x * da.x() * da.x();
+      total_cost += params.R_y * da.y() * da.y();
+      total_cost += params.R_z * da.z() * da.z();
 
       // Control rate penalty: penalize change from previous control
-      float3 du_rate;
-      du_rate.x = u.x - u_prev_timestep.x;
-      du_rate.y = u.y - u_prev_timestep.y;
-      du_rate.z = u.z - u_prev_timestep.z;
-      total_cost += params.R_rate_x * du_rate.x * du_rate.x;
-      total_cost += params.R_rate_y * du_rate.y * du_rate.y;
-      total_cost += params.R_rate_z * du_rate.z * du_rate.z;
+      Eigen::Vector3f du_rate = u - u_prev_timestep;
+      total_cost += params.R_rate_x * du_rate.x() * du_rate.x();
+      total_cost += params.R_rate_y * du_rate.y() * du_rate.y();
+      total_cost += params.R_rate_z * du_rate.z() * du_rate.z();
 
       // Update previous control for next timestep
       u_prev_timestep = u;

--- a/src/i_mppi/mppi_control/src/mppi_acc_node.cpp
+++ b/src/i_mppi/mppi_control/src/mppi_acc_node.cpp
@@ -94,8 +94,7 @@ namespace mppi_control
     if (ready)
     {
       runMPPI();
-      Eigen::Vector3d ref_acc(ref_cmd_.acceleration.x, ref_cmd_.acceleration.y, ref_cmd_.acceleration.z);
-      des_acc = u_mean_[0] + ref_acc;
+      des_acc = u_mean_[0];
       u_prev_ = u_mean_[0];
     }
     else

--- a/src/i_mppi/mppi_control/src/mppi_acc_node.cpp
+++ b/src/i_mppi/mppi_control/src/mppi_acc_node.cpp
@@ -19,7 +19,7 @@ namespace mppi_control
     common_params_.lambda = this->declare_parameter("mppi.lambda", 0.1);
     common_params_.w_obs = this->declare_parameter("mppi.w_obs", 100.0);
     common_params_.g = this->declare_parameter("mppi.g", 9.81);
-    
+
     // Low-pass filter common params
     common_params_.enable_lpf = this->declare_parameter("mppi.enable_lpf", false);
     common_params_.lpf_cutoff = this->declare_parameter("mppi.lpf_cutoff", 5.0);
@@ -40,9 +40,9 @@ namespace mppi_control
     acc_params_.R_rate_x = this->declare_parameter("mppi.R_rate_x", 0.5);
     acc_params_.R_rate_y = this->declare_parameter("mppi.R_rate_y", 0.5);
     acc_params_.R_rate_z = this->declare_parameter("mppi.R_rate_z", 0.5);
-    
+
     acc_params_.a_max = this->declare_parameter("mppi.a_max", 10.0);
-    acc_params_.tilt_max = this->declare_parameter("mppi.tilt_max", 0.6); 
+    acc_params_.tilt_max = this->declare_parameter("mppi.tilt_max", 0.6);
 
     lpf_initialized_ = false;
     acc_filtered_.setZero();
@@ -59,7 +59,7 @@ namespace mppi_control
 
     // Initialize Base (Subscribers/Publishers/Timer)
     initBase();
-    
+
     // Validate
     validateAndLogParameters();
 
@@ -69,19 +69,21 @@ namespace mppi_control
   void MPPIAccNode::validateAndLogParameters()
   {
     validateCommonParameters(common_params_);
-    
+
     // Log Specifics
     RCLCPP_INFO(this->get_logger(), "=== MPPI ACC Configuration ===");
     RCLCPP_INFO(this->get_logger(), "  sigma: %.3f", acc_params_.sigma);
     RCLCPP_INFO(this->get_logger(), "  Q_pos: [%.1f, %.1f, %.1f]",
                 acc_params_.Q_pos_x, acc_params_.Q_pos_y, acc_params_.Q_pos_z);
-    
-    if (acc_params_.sigma < 0.0) RCLCPP_ERROR(this->get_logger(), "sigma must be >= 0");
+
+    if (acc_params_.sigma < 0.0)
+      RCLCPP_ERROR(this->get_logger(), "sigma must be >= 0");
   }
 
   void MPPIAccNode::controlLoop()
   {
-    if (!odom_received_) return;
+    if (!odom_received_)
+      return;
 
     checkTiming();
     auto start_time = std::chrono::high_resolution_clock::now();
@@ -106,10 +108,13 @@ namespace mppi_control
 
     if (common_params_.enable_lpf)
     {
-      if (!lpf_initialized_) {
+      if (!lpf_initialized_)
+      {
         acc_filtered_ = des_acc;
         lpf_initialized_ = true;
-      } else {
+      }
+      else
+      {
         acc_filtered_ = common_params_.lpf_alpha * des_acc + (1.0 - common_params_.lpf_alpha) * acc_filtered_;
       }
     }
@@ -134,7 +139,7 @@ namespace mppi_control
     if (ready)
     {
       publish_execution_time(comp_time_pub_, start_time);
-      
+
       // Shift control sequence
       for (int i = 0; i < common_params_.H - 1; ++i)
       {


### PR DESCRIPTION
Refactors mppi_acc CUDA kernels to use Eigen for vectorized operations and improved readability, as requested in #11.