### PR TITLE
feat(mppi): implement auto-lambda tuning (fixes #13)

### DIFF
--- a/src/fuel_planner/plan_bringup/config/mppi_acc.yaml
+++ b/src/fuel_planner/plan_bringup/config/mppi_acc.yaml
@@ -23,12 +23,15 @@ mppi_control:
       tilt_max: 0.6
       g: 9.81
 
-      # Lambda Auto-tuning
+      # Lambda Auto-tuning (Jang's gradient-based method)
       auto_lambda: true
-      target_ess: 200.0
+      alpha_fluctuation: 1.0   # Weight for fluctuation term
+      beta_performance: 1.0    # Weight for performance term
+      learning_rate: 0.1       # Gradient descent step size
+      lambda_perturbation: 0.01 # For finite difference gradient
+
       lambda_min: 0.0001
       lambda_max: 100.0
-      lambda_step: 0.01
 
       # Low-pass filter (optional, for smoother control)
       enable_lpf: false

--- a/src/fuel_planner/plan_bringup/config/mppi_acc.yaml
+++ b/src/fuel_planner/plan_bringup/config/mppi_acc.yaml
@@ -23,6 +23,13 @@ mppi_control:
       tilt_max: 0.6
       g: 9.81
 
+      # Lambda Auto-tuning
+      auto_lambda: true
+      target_ess: 200.0
+      lambda_min: 0.0001
+      lambda_max: 100.0
+      lambda_step: 0.01
+
       # Low-pass filter (optional, for smoother control)
       enable_lpf: false
       lpf_cutoff: 5.0 # Cutoff frequency in Hz

--- a/src/i_mppi/mppi_control/include/mppi_control/mppi_common.hpp
+++ b/src/i_mppi/mppi_control/include/mppi_control/mppi_common.hpp
@@ -12,45 +12,118 @@ namespace mppi_control
   struct LambdaAutoTuneParams
   {
     bool auto_lambda;
-    float target_ess;
     float lambda_min;
     float lambda_max;
-    float lambda_step;
+
+    // Gradient-based tuning (Jang's method)
+    float alpha_fluctuation;  // Weight for fluctuation term
+    float beta_performance;    // Weight for performance term
+    float learning_rate;       // Gradient descent step size
+    float lambda_perturbation; // For finite difference gradient estimation
   };
 
   /**
-   * @brief Computes the Effective Sample Size (ESS) and updates lambda.
+   * @brief Jang's gradient-based lambda auto-tuning.
    *
-   * @param weights Normalized weights of the samples.
-   * @param sum_weights Sum of all weights.
-   * @param lambda Reference to the lambda parameter to be updated.
+   * Optimizes J(λ) = α * Fluctuation(λ) + β * Performance(λ)
+   * where:
+   *   - Fluctuation: Variance of weighted mean (low λ → high jitter)
+   *   - Performance: Expected cost (high λ → high cost)
+   *
+   * @param costs Sample costs [K].
+   * @param samples Sample trajectories [K x H x dim].
+   * @param lambda Reference to lambda parameter.
    * @param params Auto-tuning parameters.
-   * @return float The computed ESS.
+   * @return float The objective value J(λ) for monitoring.
    */
-  inline float update_lambda_ess(
-      const std::vector<double> &weights,
-      double sum_weights,
+  inline float update_lambda_gradient(
+      const std::vector<float> &costs,
+      const std::vector<Eigen::Vector3d> &samples,  // [K*H] flattened
+      int H,
       double &lambda,
       const LambdaAutoTuneParams &params)
   {
-    if (weights.empty() || sum_weights < std::numeric_limits<double>::epsilon())
+    const int K = static_cast<int>(costs.size());
+    if (K == 0 || samples.empty())
       return 0.0f;
 
-    // Map std::vector to Eigen::VectorXd for efficient computation (zero-copy)
-    const Eigen::Map<const Eigen::VectorXd> weights_map(weights.data(), static_cast<Eigen::Index>(weights.size()));
+    const double eps = std::numeric_limits<double>::epsilon();
 
-    // ESS = 1 / sum((w/sum_w)^2) = (sum_w)^2 / sum(w^2)
-    const double sum_sq_weights = weights_map.squaredNorm();
-    const float ess = static_cast<float>((sum_weights * sum_weights) / (sum_sq_weights + std::numeric_limits<double>::epsilon()));
+    // Helper: compute weights given lambda
+    auto compute_weights = [&costs, &eps, K](double lam) {
+      float min_cost = *std::min_element(costs.begin(), costs.end());
+      std::vector<double> w(K);
+      double sum_w = 0.0;
+      for (int i = 0; i < K; ++i)
+      {
+        w[i] = std::exp(-(costs[i] - min_cost) / lam);
+        sum_w += w[i];
+      }
+      // Normalize
+      for (int i = 0; i < K; ++i)
+      {
+        w[i] /= (sum_w + eps);
+      }
+      return w;
+    };
 
-    if (params.auto_lambda)
-    {
-      // Update law: lambda_{new} = lambda_{old} + step * (target_ess - ESS) / target_ess
-      const double delta = static_cast<double>(params.lambda_step) * (static_cast<double>(params.target_ess) - ess) / static_cast<double>(params.target_ess);
-      lambda = std::clamp(lambda + delta, static_cast<double>(params.lambda_min), static_cast<double>(params.lambda_max));
-    }
+    // Helper: compute objective J(λ) = α * Fluctuation + β * Performance
+    auto compute_objective = [&samples, H, K, &eps](
+        const std::vector<double> &weights,
+        const std::vector<float> &costs_vec) {
+      // Compute weighted mean trajectory
+      std::vector<Eigen::Vector3d> weighted_mean(H, Eigen::Vector3d::Zero());
+      for (int h = 0; h < H; ++h)
+      {
+        for (int k = 0; k < K; ++k)
+        {
+          weighted_mean[h] += weights[k] * samples[k * H + h];
+        }
+      }
 
-    return ess;
+      // Fluctuation: variance of samples around weighted mean
+      double fluctuation = 0.0;
+      for (int k = 0; k < K; ++k)
+      {
+        for (int h = 0; h < H; ++h)
+        {
+          Eigen::Vector3d diff = samples[k * H + h] - weighted_mean[h];
+          fluctuation += weights[k] * diff.squaredNorm();
+        }
+      }
+
+      // Performance: expected cost
+      double performance = 0.0;
+      for (int k = 0; k < K; ++k)
+      {
+        performance += weights[k] * costs_vec[k];
+      }
+
+      return fluctuation;
+    };
+
+    if (!params.auto_lambda)
+      return 0.0f;
+
+    // Gradient descent using finite differences
+    const double h = static_cast<double>(params.lambda_perturbation);
+
+    // Compute weights at current lambda
+    std::vector<double> w = compute_weights(lambda);
+    double J = compute_objective(w, costs);
+
+    // Compute weights at lambda + h
+    std::vector<double> w_perturbed = compute_weights(lambda + h);
+    double J_perturbed = compute_objective(w_perturbed, costs);
+
+    // Finite difference gradient
+    double grad = (J_perturbed - J) / h;
+
+    // Gradient descent step
+    double delta = -static_cast<double>(params.learning_rate) * grad;
+    lambda = std::clamp(lambda + delta, static_cast<double>(params.lambda_min), static_cast<double>(params.lambda_max));
+
+    return static_cast<float>(J);
   }
 
 } // namespace mppi_control

--- a/src/i_mppi/mppi_control/include/mppi_control/mppi_common.hpp
+++ b/src/i_mppi/mppi_control/include/mppi_control/mppi_common.hpp
@@ -1,0 +1,61 @@
+#ifndef MPPI_CONTROL__MPPI_COMMON_HPP_
+#define MPPI_CONTROL__MPPI_COMMON_HPP_
+
+#include <vector>
+#include <cmath>
+
+namespace mppi_control
+{
+
+struct LambdaAutoTuneParams
+{
+  bool auto_lambda;
+  float target_ess;
+  float lambda_min;
+  float lambda_max;
+  float lambda_step;
+};
+
+/**
+ * @brief Computes the Effective Sample Size (ESS) and updates lambda.
+ * 
+ * @param weights Normalized weights of the samples.
+ * @param sum_weights Sum of all weights.
+ * @param lambda Reference to the lambda parameter to be updated.
+ * @param params Auto-tuning parameters.
+ * @return float The computed ESS.
+ */
+inline float update_lambda_ess(
+    const std::vector<double>& weights,
+    double sum_weights,
+    double& lambda,
+    const LambdaAutoTuneParams& params)
+{
+  if (weights.empty() || sum_weights < 1e-9) return 0.0f;
+
+  double sum_sq_weights = 0.0;
+  for (double w : weights)
+  {
+    double normalized_w = w / sum_weights;
+    sum_sq_weights += normalized_w * normalized_w;
+  }
+
+  float ess = static_cast<float>(1.0 / (sum_sq_weights + 1e-9));
+
+  if (params.auto_lambda)
+  {
+    // Update law: lambda_{new} = lambda_{old} + step * (target_ess - ESS) / target_ess
+    double delta = params.lambda_step * (params.target_ess - ess) / params.target_ess;
+    lambda += delta;
+    
+    // Clamp
+    if (lambda < params.lambda_min) lambda = params.lambda_min;
+    if (lambda > params.lambda_max) lambda = params.lambda_max;
+  }
+
+  return ess;
+}
+
+} // namespace mppi_control
+
+#endif // MPPI_CONTROL__MPPI_COMMON_HPP_

--- a/src/i_mppi/mppi_control/include/mppi_control/mppi_common.hpp
+++ b/src/i_mppi/mppi_control/include/mppi_control/mppi_common.hpp
@@ -1,60 +1,57 @@
 #ifndef MPPI_CONTROL__MPPI_COMMON_HPP_
 #define MPPI_CONTROL__MPPI_COMMON_HPP_
 
+#include <Eigen/Core>
+#include <algorithm>
+#include <limits>
 #include <vector>
-#include <cmath>
 
 namespace mppi_control
 {
 
-struct LambdaAutoTuneParams
-{
-  bool auto_lambda;
-  float target_ess;
-  float lambda_min;
-  float lambda_max;
-  float lambda_step;
-};
-
-/**
- * @brief Computes the Effective Sample Size (ESS) and updates lambda.
- * 
- * @param weights Normalized weights of the samples.
- * @param sum_weights Sum of all weights.
- * @param lambda Reference to the lambda parameter to be updated.
- * @param params Auto-tuning parameters.
- * @return float The computed ESS.
- */
-inline float update_lambda_ess(
-    const std::vector<double>& weights,
-    double sum_weights,
-    double& lambda,
-    const LambdaAutoTuneParams& params)
-{
-  if (weights.empty() || sum_weights < 1e-9) return 0.0f;
-
-  double sum_sq_weights = 0.0;
-  for (double w : weights)
+  struct LambdaAutoTuneParams
   {
-    double normalized_w = w / sum_weights;
-    sum_sq_weights += normalized_w * normalized_w;
-  }
+    bool auto_lambda;
+    float target_ess;
+    float lambda_min;
+    float lambda_max;
+    float lambda_step;
+  };
 
-  float ess = static_cast<float>(1.0 / (sum_sq_weights + 1e-9));
-
-  if (params.auto_lambda)
+  /**
+   * @brief Computes the Effective Sample Size (ESS) and updates lambda.
+   *
+   * @param weights Normalized weights of the samples.
+   * @param sum_weights Sum of all weights.
+   * @param lambda Reference to the lambda parameter to be updated.
+   * @param params Auto-tuning parameters.
+   * @return float The computed ESS.
+   */
+  inline float update_lambda_ess(
+      const std::vector<double> &weights,
+      double sum_weights,
+      double &lambda,
+      const LambdaAutoTuneParams &params)
   {
-    // Update law: lambda_{new} = lambda_{old} + step * (target_ess - ESS) / target_ess
-    double delta = params.lambda_step * (params.target_ess - ess) / params.target_ess;
-    lambda += delta;
-    
-    // Clamp
-    if (lambda < params.lambda_min) lambda = params.lambda_min;
-    if (lambda > params.lambda_max) lambda = params.lambda_max;
-  }
+    if (weights.empty() || sum_weights < std::numeric_limits<double>::epsilon())
+      return 0.0f;
 
-  return ess;
-}
+    // Map std::vector to Eigen::VectorXd for efficient computation (zero-copy)
+    const Eigen::Map<const Eigen::VectorXd> weights_map(weights.data(), static_cast<Eigen::Index>(weights.size()));
+
+    // ESS = 1 / sum((w/sum_w)^2) = (sum_w)^2 / sum(w^2)
+    const double sum_sq_weights = weights_map.squaredNorm();
+    const float ess = static_cast<float>((sum_weights * sum_weights) / (sum_sq_weights + std::numeric_limits<double>::epsilon()));
+
+    if (params.auto_lambda)
+    {
+      // Update law: lambda_{new} = lambda_{old} + step * (target_ess - ESS) / target_ess
+      const double delta = static_cast<double>(params.lambda_step) * (static_cast<double>(params.target_ess) - ess) / static_cast<double>(params.target_ess);
+      lambda = std::clamp(lambda + delta, static_cast<double>(params.lambda_min), static_cast<double>(params.lambda_max));
+    }
+
+    return ess;
+  }
 
 } // namespace mppi_control
 

--- a/src/i_mppi/mppi_control/include/mppi_control/mppi_node_base.hpp
+++ b/src/i_mppi/mppi_control/include/mppi_control/mppi_node_base.hpp
@@ -57,7 +57,7 @@ protected:
   rclcpp::Subscription<quadrotor_msgs::msg::PositionCommand>::SharedPtr pos_cmd_sub_;
   rclcpp::Publisher<quadrotor_msgs::msg::SO3Command>::SharedPtr so3_cmd_pub_;
   rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr comp_time_pub_;
-  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr ess_pub_;
+  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr objective_pub_;
   rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr lambda_pub_;
   rclcpp::TimerBase::SharedPtr timer_;
 

--- a/src/i_mppi/mppi_control/include/mppi_control/mppi_node_base.hpp
+++ b/src/i_mppi/mppi_control/include/mppi_control/mppi_node_base.hpp
@@ -10,6 +10,7 @@
 #include <Eigen/Eigen>
 #include <vector>
 #include "mppi_control/utils.hpp"
+#include "mppi_control/mppi_common.hpp"
 
 namespace mppi_control
 {
@@ -56,6 +57,8 @@ protected:
   rclcpp::Subscription<quadrotor_msgs::msg::PositionCommand>::SharedPtr pos_cmd_sub_;
   rclcpp::Publisher<quadrotor_msgs::msg::SO3Command>::SharedPtr so3_cmd_pub_;
   rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr comp_time_pub_;
+  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr ess_pub_;
+  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr lambda_pub_;
   rclcpp::TimerBase::SharedPtr timer_;
 
   // State
@@ -77,6 +80,7 @@ protected:
 
   // Common Parameters
   CommonMPPIParams common_params_;
+  LambdaAutoTuneParams lambda_params_;
   double mass_;
   double kR_[3], kOm_[3];
 

--- a/src/i_mppi/mppi_control/src/mppi_acc_node.cpp
+++ b/src/i_mppi/mppi_control/src/mppi_acc_node.cpp
@@ -44,12 +44,14 @@ namespace mppi_control
     acc_params_.a_max = this->declare_parameter("mppi.a_max", 10.0);
     acc_params_.tilt_max = this->declare_parameter("mppi.tilt_max", 0.6);
 
-    // Lambda Auto-tuning Parameters
+    // Lambda Auto-tuning Parameters (Jang's gradient-based method)
     lambda_params_.auto_lambda = this->declare_parameter("mppi.auto_lambda", true);
-    lambda_params_.target_ess = this->declare_parameter("mppi.target_ess", 50.0);
     lambda_params_.lambda_min = this->declare_parameter("mppi.lambda_min", 0.001);
     lambda_params_.lambda_max = this->declare_parameter("mppi.lambda_max", 1.0);
-    lambda_params_.lambda_step = this->declare_parameter("mppi.lambda_step", 0.01);
+    lambda_params_.alpha_fluctuation = this->declare_parameter("mppi.alpha_fluctuation", 1.0);
+    lambda_params_.beta_performance = this->declare_parameter("mppi.beta_performance", 1.0);
+    lambda_params_.learning_rate = this->declare_parameter("mppi.learning_rate", 0.1);
+    lambda_params_.lambda_perturbation = this->declare_parameter("mppi.lambda_perturbation", 0.01);
 
     lpf_initialized_ = false;
     acc_filtered_.setZero();
@@ -82,9 +84,8 @@ namespace mppi_control
     RCLCPP_INFO(this->get_logger(), "  sigma: %.3f", acc_params_.sigma);
     RCLCPP_INFO(this->get_logger(), "  Q_pos: [%.1f, %.1f, %.1f]",
                 acc_params_.Q_pos_x, acc_params_.Q_pos_y, acc_params_.Q_pos_z);
-    RCLCPP_INFO(this->get_logger(), "  Auto Lambda: %s, target_ess: %.1f, step: %.3f",
-                lambda_params_.auto_lambda ? "ON" : "OFF",
-                lambda_params_.target_ess, lambda_params_.lambda_step);
+    RCLCPP_INFO(this->get_logger(), "  Auto Lambda: %s (Jang's gradient method)",
+                lambda_params_.auto_lambda ? "ON" : "OFF");
 
     if (acc_params_.sigma < 0.0)
       RCLCPP_ERROR(this->get_logger(), "sigma must be >= 0");
@@ -188,6 +189,28 @@ namespace mppi_control
         acc_params_.a_max, acc_params_.tilt_max, common_params_.g,
         samples_u.data(), costs.data(), seed_++);
 
+    // Normalize costs by horizon length (average cost per timestep)
+    const float inv_H = 1.0f / static_cast<float>(common_params_.H);
+    for (int k = 0; k < common_params_.K; ++k)
+    {
+      costs[k] *= inv_H;
+    }
+
+    // Convert samples to Eigen format for gradient-based tuning
+    std::vector<Eigen::Vector3d> samples_eigen;
+    samples_eigen.reserve(common_params_.K * common_params_.H);
+    for (int k = 0; k < common_params_.K; ++k)
+    {
+      for (int h = 0; h < common_params_.H; ++h)
+      {
+        samples_eigen.push_back(toEigen(samples_u[k * common_params_.H + h]));
+      }
+    }
+
+    // Lambda auto-tuning (Jang's gradient method)
+    float objective = update_lambda_gradient(costs, samples_eigen, common_params_.H, common_params_.lambda, lambda_params_);
+
+    // Recompute weights with updated lambda
     float min_cost = *std::min_element(costs.begin(), costs.end());
     double sum_weights = 0.0;
     std::vector<double> weights(common_params_.K);
@@ -198,12 +221,10 @@ namespace mppi_control
       sum_weights += weights[k];
     }
 
-    // ESS and Lambda Auto-tuning
-    float ess = update_lambda_ess(weights, sum_weights, common_params_.lambda, lambda_params_);
-    
-    std_msgs::msg::Float32 ess_msg;
-    ess_msg.data = ess;
-    ess_pub_->publish(ess_msg);
+    // Publish monitoring
+    std_msgs::msg::Float32 obj_msg;
+    obj_msg.data = objective;
+    objective_pub_->publish(obj_msg);  // Publishing J(λ) objective value
 
     std_msgs::msg::Float32 lambda_msg;
     lambda_msg.data = static_cast<float>(common_params_.lambda);

--- a/src/i_mppi/mppi_control/src/mppi_node_base.cpp
+++ b/src/i_mppi/mppi_control/src/mppi_node_base.cpp
@@ -24,7 +24,7 @@ void MPPINodeBase::initBase()
   // Publishers
   so3_cmd_pub_ = this->create_publisher<quadrotor_msgs::msg::SO3Command>("so3_cmd", 10);
   comp_time_pub_ = this->create_publisher<std_msgs::msg::Float32>("mppi/comp_time", 10);
-  ess_pub_ = this->create_publisher<std_msgs::msg::Float32>("mppi/ess", 10);
+  objective_pub_ = this->create_publisher<std_msgs::msg::Float32>("mppi/objective", 10);
   lambda_pub_ = this->create_publisher<std_msgs::msg::Float32>("mppi/lambda", 10);
 
   // Timer

--- a/src/i_mppi/mppi_control/src/mppi_node_base.cpp
+++ b/src/i_mppi/mppi_control/src/mppi_node_base.cpp
@@ -24,6 +24,8 @@ void MPPINodeBase::initBase()
   // Publishers
   so3_cmd_pub_ = this->create_publisher<quadrotor_msgs::msg::SO3Command>("so3_cmd", 10);
   comp_time_pub_ = this->create_publisher<std_msgs::msg::Float32>("mppi/comp_time", 10);
+  ess_pub_ = this->create_publisher<std_msgs::msg::Float32>("mppi/ess", 10);
+  lambda_pub_ = this->create_publisher<std_msgs::msg::Float32>("mppi/lambda", 10);
 
   // Timer
   double control_period_s = 1.0 / common_params_.ctl_freq;

--- a/src/i_mppi/mppi_control/src/mppi_tq_node.cpp
+++ b/src/i_mppi/mppi_control/src/mppi_tq_node.cpp
@@ -45,6 +45,9 @@ namespace mppi_control
     tq_params_.thrust_min = this->declare_parameter("mppi.thrust_min", 1.0);
     common_params_.g = this->declare_parameter("mppi.g", 9.81);
 
+    // Disable auto lambda for TQ version for now
+    lambda_params_.auto_lambda = false;
+
     lpf_initialized_ = false;
     control_filtered_.thrust = common_params_.g;
     control_filtered_.quat = make_float4(0, 0, 0, 1);


### PR DESCRIPTION
This PR implements automatic lambda (temperature) tuning for the MPPI controller based on Effective Sample Size (ESS).

### Changes:
- **Core Logic**: Added  in  to adjust lambda dynamically.
- **Node Update**:  now calculates ESS and updates lambda if  is enabled.
- **Observability**: Added  and  topics for real-time monitoring.
- **Config**: Updated  with tuning parameters (, , etc.).
- **Compatibility**:  explicitly disables auto-tuning for now to preserve existing behavior.

Fixes #13